### PR TITLE
Show only matches according to template

### DIFF
--- a/src/core/database.h
+++ b/src/core/database.h
@@ -142,12 +142,15 @@ class Database {
     int ReturnNumberOfAlignmentJobs( );
     int ReturnNumberOfCTFEstimationJobs( );
     int ReturnNumberOfTemplateMatchingJobs( );
+    int ReturnNumberOfTemplateMatchingJobsGivenVolumeAssetId(int wanted_asset_id);
     int ReturnNumberOfPickingJobs( );
     int ReturnNumberOfImageAssetsWithCTFEstimates( );
 
     void GetUniqueAlignmentIDs(int* alignment_job_ids, int number_of_alignmnet_jobs);
     void GetUniqueCTFEstimationIDs(int* ctf_estimation_job_ids, int number_of_ctf_estimation_jobs);
     void GetUniqueTemplateMatchIDs(long* template_match_job_ids, int number_of_template_match_jobs);
+    void GetUniqueTemplateMatchIDsGivenVolumeAssetId(long* template_match_job_ids, int number_of_template_match_jobs, int wanted_asset_id);
+
     void GetUniquePickingJobIDs(int* picking_job_ids, int number_of_picking_jobs);
     void GetUniqueIDsOfImagesWithCTFEstimations(int* image_ids, int& number_of_image_ids);
 
@@ -341,7 +344,7 @@ class Database {
     void AddTemplateMatchingResult(long wanted_template_match_id, TemplateMatchJobResults& job_details);
 
     TemplateMatchJobResults GetTemplateMatchingResultByID(long wanted_template_match_id);
-    long GetTemplateMatchIdForGivenJobId(long wanted_template_match_job_id);
+    long                    GetTemplateMatchIdForGivenJobId(long wanted_template_match_job_id);
 
     void AddRefinementAngularDistribution(AngularDistributionHistogram& histogram_to_add, long refinement_id, int class_number);
     void CopyRefinementAngularDistributions(long refinement_id_to_copy, long refinement_id_to_copy_to, int wanted_class_number);

--- a/src/gui/MainFrame.cpp
+++ b/src/gui/MainFrame.cpp
@@ -291,6 +291,8 @@ void MyMainFrame::DirtyVolumes( ) {
 #ifdef EXPERIMENTAL
     match_template_panel->volumes_are_dirty  = true;
     refine_template_panel->volumes_are_dirty = true;
+    match_template_results_panel->volumes_are_dirty = true;
+
 #endif
 }
 

--- a/src/gui/MatchTemplateResultsPanel.h
+++ b/src/gui/MatchTemplateResultsPanel.h
@@ -9,7 +9,7 @@ class MatchTemplateResultsPanel : public MatchTemplateResultsPanelParent {
     void OnUpdateUI(wxUpdateUIEvent& event);
     void OnValueChanged(wxDataViewEvent& event);
     void FillGroupComboBox( );
-    void FillBasedOnSelectCommand(wxString wanted_command);
+    void FillBasedOnSelectCommand(wxString wanted_command, int wanted_volume_asset_id = -1);
     int  ReturnRowFromAssetID(int asset_id, int start_location = 0);
     void OnAddAllToGroupClick(wxCommandEvent& event);
     void FillResultsPanelAndDetails(int row, int column);
@@ -18,6 +18,7 @@ class MatchTemplateResultsPanel : public MatchTemplateResultsPanelParent {
     void OnAddToGroupClick(wxCommandEvent& event);
     void OnRemoveFromGroupClick(wxCommandEvent& event);
     void OnJobDetailsToggle(wxCommandEvent& event);
+    void OnTemplateComboBox(wxCommandEvent& event);
     void Clear( );
 
     int  GetFilter( );
@@ -38,6 +39,7 @@ class MatchTemplateResultsPanel : public MatchTemplateResultsPanelParent {
 
     bool is_dirty;
     bool group_combo_is_dirty;
+    bool volumes_are_dirty;
 
     wxString current_fill_command;
 };

--- a/src/gui/ProjectX_gui.cpp
+++ b/src/gui/ProjectX_gui.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct 26 2018)
+// C++ code generated with wxFormBuilder (version 3.10.0-4761b0c)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO *NOT* EDIT THIS FILE!
@@ -3211,24 +3211,18 @@ MatchTemplateResultsPanelParent::MatchTemplateResultsPanelParent( wxWindow* pare
 	wxBoxSizer* bSizer64;
 	bSizer64 = new wxBoxSizer( wxHORIZONTAL );
 
-	AllImagesButton = new wxRadioButton( m_panel13, wxID_ANY, wxT("All Images"), wxDefaultPosition, wxDefaultSize, 0 );
-	AllImagesButton->Hide();
+	m_staticText809 = new wxStaticText( m_panel13, wxID_ANY, wxT("Template:"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_staticText809->Wrap( -1 );
+	bSizer64->Add( m_staticText809, 0, wxALL, 5 );
 
-	bSizer64->Add( AllImagesButton, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+	TemplateComboBox = new VolumeAssetPickerComboPanel( m_panel13, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
+	TemplateComboBox->SetMinSize( wxSize( 350,-1 ) );
+	TemplateComboBox->SetMaxSize( wxSize( 350,-1 ) );
 
-	ByFilterButton = new wxRadioButton( m_panel13, wxID_ANY, wxT("By Filter"), wxDefaultPosition, wxDefaultSize, 0 );
-	ByFilterButton->Hide();
-
-	bSizer64->Add( ByFilterButton, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-
-	FilterButton = new wxButton( m_panel13, wxID_ANY, wxT("Define Filter"), wxDefaultPosition, wxDefaultSize, 0 );
-	FilterButton->Enable( false );
-	FilterButton->Hide();
-
-	bSizer64->Add( FilterButton, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
+	bSizer64->Add( TemplateComboBox, 1, wxEXPAND | wxALL, 5 );
 
 
-	bSizer64->Add( 0, 0, 1, wxEXPAND, 5 );
+	bSizer64->Add( 0, 0, 0, wxEXPAND, 5 );
 
 	m_staticline77 = new wxStaticLine( m_panel13, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLI_HORIZONTAL|wxLI_VERTICAL );
 	bSizer64->Add( m_staticline77, 0, wxEXPAND | wxALL, 5 );
@@ -3582,9 +3576,6 @@ MatchTemplateResultsPanelParent::MatchTemplateResultsPanelParent( wxWindow* pare
 
 	// Connect Events
 	this->Connect( wxEVT_UPDATE_UI, wxUpdateUIEventHandler( MatchTemplateResultsPanelParent::OnUpdateUI ) );
-	AllImagesButton->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( MatchTemplateResultsPanelParent::OnAllImagesSelect ), NULL, this );
-	ByFilterButton->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( MatchTemplateResultsPanelParent::OnByFilterSelect ), NULL, this );
-	FilterButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( MatchTemplateResultsPanelParent::OnDefineFilterClick ), NULL, this );
 	JobDetailsToggleButton->Connect( wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler( MatchTemplateResultsPanelParent::OnJobDetailsToggle ), NULL, this );
 	PreviousButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( MatchTemplateResultsPanelParent::OnPreviousButtonClick ), NULL, this );
 	AddAllToGroupButton->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( MatchTemplateResultsPanelParent::OnAddAllToGroupClick ), NULL, this );
@@ -3597,9 +3588,6 @@ MatchTemplateResultsPanelParent::~MatchTemplateResultsPanelParent()
 {
 	// Disconnect Events
 	this->Disconnect( wxEVT_UPDATE_UI, wxUpdateUIEventHandler( MatchTemplateResultsPanelParent::OnUpdateUI ) );
-	AllImagesButton->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( MatchTemplateResultsPanelParent::OnAllImagesSelect ), NULL, this );
-	ByFilterButton->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( MatchTemplateResultsPanelParent::OnByFilterSelect ), NULL, this );
-	FilterButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( MatchTemplateResultsPanelParent::OnDefineFilterClick ), NULL, this );
 	JobDetailsToggleButton->Disconnect( wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEventHandler( MatchTemplateResultsPanelParent::OnJobDetailsToggle ), NULL, this );
 	PreviousButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( MatchTemplateResultsPanelParent::OnPreviousButtonClick ), NULL, this );
 	AddAllToGroupButton->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( MatchTemplateResultsPanelParent::OnAddAllToGroupClick ), NULL, this );
@@ -11032,6 +11020,7 @@ RefineTemplateDevPanelParent::~RefineTemplateDevPanelParent()
 NewProjectWizard::NewProjectWizard( wxWindow* parent, wxWindowID id, const wxString& title, const wxBitmap& bitmap, const wxPoint& pos, long style )
 {
 	this->Create( parent, id, title, bitmap, pos, style );
+
 	this->SetSizeHints( wxSize( 500,350 ), wxDefaultSize );
 
 	wxWizardPageSimple* m_wizPage1 = new wxWizardPageSimple( this );
@@ -11114,6 +11103,7 @@ NewProjectWizard::~NewProjectWizard()
 ExportRefinementPackageWizardParent::ExportRefinementPackageWizardParent( wxWindow* parent, wxWindowID id, const wxString& title, const wxBitmap& bitmap, const wxPoint& pos, long style )
 {
 	this->Create( parent, id, title, bitmap, pos, style );
+
 	this->SetSizeHints( wxSize( 700,400 ), wxDefaultSize );
 
 	wxWizardPageSimple* ChooseParamsPage = new wxWizardPageSimple( this );
@@ -11271,6 +11261,7 @@ ExportRefinementPackageWizardParent::~ExportRefinementPackageWizardParent()
 ImportRefinementPackageWizardParent::ImportRefinementPackageWizardParent( wxWindow* parent, wxWindowID id, const wxString& title, const wxBitmap& bitmap, const wxPoint& pos, long style )
 {
 	this->Create( parent, id, title, bitmap, pos, style );
+
 	this->SetSizeHints( wxSize( 700,400 ), wxDefaultSize );
 
 	wxWizardPageSimple* ImportTypePage = new wxWizardPageSimple( this );
@@ -11671,6 +11662,7 @@ RenameDialog::~RenameDialog()
 NewRefinementPackageWizard::NewRefinementPackageWizard( wxWindow* parent, wxWindowID id, const wxString& title, const wxBitmap& bitmap, const wxPoint& pos, long style )
 {
 	this->Create( parent, id, title, bitmap, pos, style );
+
 	this->SetSizeHints( wxSize( -1,-1 ), wxDefaultSize );
 
 

--- a/src/gui/ProjectX_gui.h
+++ b/src/gui/ProjectX_gui.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct 26 2018)
+// C++ code generated with wxFormBuilder (version 3.10.0-4761b0c)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO *NOT* EDIT THIS FILE!
@@ -108,7 +108,7 @@ class MainFrame : public wxFrame
 		wxMenuItem* WorkflowTemplateMatching;
 		wxMenu* HelpMenu;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnMenuBookChange( wxListbookEvent& event ) { event.Skip(); }
 		virtual void OnFileMenuUpdate( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnFileNewProject( wxCommandEvent& event ) { event.Skip(); }
@@ -139,7 +139,7 @@ class AssetPickerComboPanelParent : public wxPanel
 
 	protected:
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnSize( wxSizeEvent& event ) { event.Skip(); }
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnPreviousButtonClick( wxCommandEvent& event ) { event.Skip(); }
@@ -153,6 +153,7 @@ class AssetPickerComboPanelParent : public wxPanel
 		NoFocusBitmapButton* WindowSelectButton;
 
 		AssetPickerComboPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( -1,-1 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~AssetPickerComboPanelParent();
 
 };
@@ -250,7 +251,7 @@ class AbInitio3DPanelParent : public JobPanel
 		MemoryComboBox* ReconstructionRunProfileComboBox;
 		wxButton* StartRefinementButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnMethodChange( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnExpertOptionsToggle( wxCommandEvent& event ) { event.Skip(); }
@@ -270,6 +271,7 @@ class AbInitio3DPanelParent : public JobPanel
 		DisplayPanel* ShowOrthDisplayPanel;
 
 		AbInitio3DPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1631,686 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~AbInitio3DPanelParent();
 
 };
@@ -344,7 +346,7 @@ class Refine2DPanel : public JobPanel
 		MemoryComboBox* RefinementRunProfileComboBox;
 		wxButton* StartRefinementButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnExpertOptionsToggle( wxCommandEvent& event ) { event.Skip(); }
 		virtual void ResetAllDefaultsClick( wxCommandEvent& event ) { event.Skip(); }
@@ -361,6 +363,7 @@ class Refine2DPanel : public JobPanel
 		DisplayPanel* ResultDisplayPanel;
 
 		Refine2DPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1363,691 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~Refine2DPanel();
 
 };
@@ -477,7 +480,7 @@ class RefinementResultsPanel : public wxPanel
 		wxStaticLine* m_staticline30;
 		DisplayPanel* OrthPanel;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void PopupParametersClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void AngularPlotPopupClick( wxCommandEvent& event ) { event.Skip(); }
@@ -491,6 +494,7 @@ class RefinementResultsPanel : public wxPanel
 		NoFocusBitmapButton* AngularPlotDetailsButton;
 
 		RefinementResultsPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1007,587 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~RefinementResultsPanel();
 
 		void m_splitter7OnIdle( wxIdleEvent& )
@@ -558,6 +562,7 @@ class ShowCTFResultsPanelParent : public wxPanel
 		DisplayPanel* ImageDisplayPanel;
 
 		ShowCTFResultsPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 952,539 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~ShowCTFResultsPanelParent();
 
 		void m_splitter16OnIdle( wxIdleEvent& )
@@ -598,7 +603,7 @@ class ShowTemplateMatchResultsPanelParent : public wxPanel
 		wxStaticText* ImageFileText;
 		wxStaticLine* m_staticline86;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnSavePeaksClick( wxCommandEvent& event ) { event.Skip(); }
 
 
@@ -610,6 +615,7 @@ class ShowTemplateMatchResultsPanelParent : public wxPanel
 		DisplayPanel* ImageDisplayPanel;
 
 		ShowTemplateMatchResultsPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 952,539 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~ShowTemplateMatchResultsPanelParent();
 
 		void m_splitter16OnIdle( wxIdleEvent& )
@@ -695,7 +701,7 @@ class Refine2DResultsPanelParent : public wxPanel
 		wxStaticLine* m_staticline65;
 		DisplayPanel* ParticleDisplayPanel;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnJobDetailsToggle( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnBeginLabelEdit( wxListEvent& event ) { event.Skip(); }
@@ -716,6 +722,7 @@ class Refine2DResultsPanelParent : public wxPanel
 		ClassificationPickerComboPanel* InputParametersComboBox;
 
 		Refine2DResultsPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1269,471 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~Refine2DResultsPanelParent();
 
 		void m_splitter7OnIdle( wxIdleEvent& )
@@ -749,7 +756,7 @@ class PickingResultsDisplayPanelParent : public wxPanel
 		wxStaticLine* m_staticline8311;
 		wxStaticLine* m_staticline26;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnCirclesAroundParticlesCheckBox( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnScaleBarCheckBox( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnHighPassFilterCheckBox( wxCommandEvent& event ) { event.Skip(); }
@@ -767,6 +774,7 @@ class PickingResultsDisplayPanelParent : public wxPanel
 		wxButton* RedoButton;
 
 		PickingResultsDisplayPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1123,360 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~PickingResultsDisplayPanelParent();
 
 };
@@ -843,7 +851,7 @@ class FindCTFResultsPanel : public wxPanel
 		wxButton* AddToGroupButton;
 		MemoryComboBox* GroupComboBox;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnAllMoviesSelect( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnByFilterSelect( wxCommandEvent& event ) { event.Skip(); }
@@ -861,6 +869,7 @@ class FindCTFResultsPanel : public wxPanel
 		NoFocusBitmapButton* PlotResultsButton;
 
 		FindCTFResultsPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 895,557 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~FindCTFResultsPanel();
 
 		void m_splitter4OnIdle( wxIdleEvent& )
@@ -882,9 +891,7 @@ class MatchTemplateResultsPanelParent : public wxPanel
 		wxStaticLine* m_staticline25;
 		wxSplitterWindow* m_splitter4;
 		wxPanel* m_panel13;
-		wxRadioButton* AllImagesButton;
-		wxRadioButton* ByFilterButton;
-		wxButton* FilterButton;
+		wxStaticText* m_staticText809;
 		wxStaticLine* m_staticline77;
 		wxToggleButton* JobDetailsToggleButton;
 		ResultsDataViewListCtrl* ResultDataView;
@@ -949,11 +956,8 @@ class MatchTemplateResultsPanelParent : public wxPanel
 		wxButton* AddToGroupButton;
 		MemoryComboBox* GroupComboBox;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
-		virtual void OnAllImagesSelect( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnByFilterSelect( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnDefineFilterClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnJobDetailsToggle( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnPreviousButtonClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnAddAllToGroupClick( wxCommandEvent& event ) { event.Skip(); }
@@ -963,8 +967,10 @@ class MatchTemplateResultsPanelParent : public wxPanel
 
 
 	public:
+		VolumeAssetPickerComboPanel* TemplateComboBox;
 
 		MatchTemplateResultsPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 895,557 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~MatchTemplateResultsPanelParent();
 
 		void m_splitter4OnIdle( wxIdleEvent& )
@@ -1029,7 +1035,7 @@ class PickingResultsPanel : public wxPanel
 		wxButton* AddToGroupButton;
 		MemoryComboBox* GroupComboBox;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnAllMoviesSelect( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnByFilterSelect( wxCommandEvent& event ) { event.Skip(); }
@@ -1045,6 +1051,7 @@ class PickingResultsPanel : public wxPanel
 		PickingResultsDisplayPanel* ResultDisplayPanel;
 
 		PickingResultsPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1309,557 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~PickingResultsPanel();
 
 		void m_splitter4OnIdle( wxIdleEvent& )
@@ -1123,7 +1130,7 @@ class MovieAlignResultsPanel : public wxPanel
 		wxButton* AddToGroupButton;
 		MemoryComboBox* GroupComboBox;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnAllMoviesSelect( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnByFilterSelect( wxCommandEvent& event ) { event.Skip(); }
@@ -1139,6 +1146,7 @@ class MovieAlignResultsPanel : public wxPanel
 	public:
 
 		MovieAlignResultsPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1165,564 ), long style = wxTAB_TRAVERSAL|wxWANTS_CHARS, const wxString& name = wxEmptyString );
+
 		~MovieAlignResultsPanel();
 
 		void m_splitter4OnIdle( wxIdleEvent& )
@@ -1159,7 +1167,7 @@ class ActionsPanelParent : public wxPanel
 	protected:
 		wxStaticLine* m_staticline3;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnActionsBookPageChanged( wxListbookEvent& event ) { event.Skip(); }
 
 
@@ -1167,6 +1175,7 @@ class ActionsPanelParent : public wxPanel
 		wxListbook* ActionsBook;
 
 		ActionsPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 500,300 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~ActionsPanelParent();
 
 };
@@ -1181,7 +1190,7 @@ class SettingsPanel : public wxPanel
 	protected:
 		wxStaticLine* m_staticline3;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnSettingsBookPageChanged( wxListbookEvent& event ) { event.Skip(); }
 
 
@@ -1189,6 +1198,7 @@ class SettingsPanel : public wxPanel
 		wxListbook* SettingsBook;
 
 		SettingsPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 500,300 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~SettingsPanel();
 
 };
@@ -1203,7 +1213,7 @@ class ResultsPanel : public wxPanel
 	protected:
 		wxStaticLine* m_staticline3;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnResultsBookPageChanged( wxListbookEvent& event ) { event.Skip(); }
 
 
@@ -1211,6 +1221,7 @@ class ResultsPanel : public wxPanel
 		wxListbook* ResultsBook;
 
 		ResultsPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 500,300 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~ResultsPanel();
 
 };
@@ -1225,7 +1236,7 @@ class AssetsPanel : public wxPanel
 	protected:
 		wxStaticLine* m_staticline68;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnAssetsBookPageChanged( wxListbookEvent& event ) { event.Skip(); }
 
 
@@ -1233,6 +1244,7 @@ class AssetsPanel : public wxPanel
 		wxListbook* AssetsBook;
 
 		AssetsPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 500,300 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~AssetsPanel();
 
 };
@@ -1247,7 +1259,7 @@ class ExperimentalPanel : public wxPanel
 	protected:
 		wxStaticLine* m_staticline68;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnExperimentalBookPageChanged( wxListbookEvent& event ) { event.Skip(); }
 
 
@@ -1255,6 +1267,7 @@ class ExperimentalPanel : public wxPanel
 		wxListbook* ExperimentalBook;
 
 		ExperimentalPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 500,300 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~ExperimentalPanel();
 
 };
@@ -1270,7 +1283,7 @@ class OverviewPanel : public wxPanel
 		wxStaticLine* m_staticline2;
 		wxPanel* WelcomePanel;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnInfoURL( wxTextUrlEvent& event ) { event.Skip(); }
 
 
@@ -1278,6 +1291,7 @@ class OverviewPanel : public wxPanel
 		wxRichTextCtrl* InfoText;
 
 		OverviewPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 500,300 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~OverviewPanel();
 
 };
@@ -1348,7 +1362,7 @@ class FindParticlesPanel : public JobPanel
 		MemoryComboBox* RunProfileComboBox;
 		wxButton* StartPickingButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnPickingAlgorithmComboBox( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnExpertOptionsToggle( wxCommandEvent& event ) { event.Skip(); }
@@ -1387,6 +1401,7 @@ class FindParticlesPanel : public JobPanel
 		PickingResultsDisplayPanel* PickingResultsPanel;
 
 		FindParticlesPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1200,731 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~FindParticlesPanel();
 
 		void FindParticlesSplitterWindowOnIdle( wxIdleEvent& )
@@ -1416,7 +1431,7 @@ class VolumeImportDialog : public wxDialog
 		wxButton* m_button13;
 		wxButton* ImportButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void AddFilesClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void AddDirectoryClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void ClearClick( wxCommandEvent& event ) { event.Skip(); }
@@ -1429,6 +1444,7 @@ class VolumeImportDialog : public wxDialog
 	public:
 
 		VolumeImportDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Import Images"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 484,539 ), long style = wxCLOSE_BOX );
+
 		~VolumeImportDialog();
 
 };
@@ -1450,7 +1466,7 @@ class AtomicCoordinatesImportDialogParent : public wxDialog
 		wxButton* m_button13;
 		wxButton* ImportButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void AddFilesClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void AddDirectoryClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void ClearClick( wxCommandEvent& event ) { event.Skip(); }
@@ -1461,6 +1477,7 @@ class AtomicCoordinatesImportDialogParent : public wxDialog
 	public:
 
 		AtomicCoordinatesImportDialogParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Import PDBx/mmCIF"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 484,539 ), long style = wxCLOSE_BOX );
+
 		~AtomicCoordinatesImportDialogParent();
 
 };
@@ -1511,7 +1528,7 @@ class MovieImportDialog : public wxDialog
 		wxButton* m_button13;
 		wxButton* ImportButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void AddFilesClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void AddDirectoryClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void ClearClick( wxCommandEvent& event ) { event.Skip(); }
@@ -1530,6 +1547,7 @@ class MovieImportDialog : public wxDialog
 	public:
 
 		MovieImportDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Import Movies"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( -1,-1 ), long style = wxCLOSE_BOX );
+
 		~MovieImportDialog();
 
 };
@@ -1559,7 +1577,7 @@ class ImageImportDialog : public wxDialog
 		wxButton* m_button13;
 		wxButton* ImportButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void AddFilesClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void AddDirectoryClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void ClearClick( wxCommandEvent& event ) { event.Skip(); }
@@ -1573,6 +1591,7 @@ class ImageImportDialog : public wxDialog
 	public:
 
 		ImageImportDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Import Images"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 484,559 ), long style = wxCLOSE_BOX );
+
 		~ImageImportDialog();
 
 };
@@ -1624,7 +1643,7 @@ class AssetPanelParent : public wxPanel
 		wxStaticText* Label9Title;
 		wxStaticText* Label9Text;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void MouseCheckGroupsVeto( wxMouseEvent& event ) { event.Skip(); }
 		virtual void MouseVeto( wxMouseEvent& event ) { event.Skip(); }
@@ -1655,6 +1674,7 @@ class AssetPanelParent : public wxPanel
 		ContentsList* ContentsListBox;
 
 		AssetPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1094,668 ), long style = wxHSCROLL|wxTAB_TRAVERSAL|wxVSCROLL, const wxString& name = wxEmptyString );
+
 		~AssetPanelParent();
 
 		void SplitterWindowOnIdle( wxIdleEvent& )
@@ -1706,7 +1726,7 @@ class RunProfilesPanel : public wxPanel
 		wxButton* RemoveCommandButton;
 		wxButton* CommandsSaveButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnProfileDClick( wxMouseEvent& event ) { event.Skip(); }
 		virtual void OnProfileLeftDown( wxMouseEvent& event ) { event.Skip(); }
@@ -1738,6 +1758,7 @@ class RunProfilesPanel : public wxPanel
 	public:
 
 		RunProfilesPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 940,517 ), long style = wxHSCROLL|wxTAB_TRAVERSAL|wxVSCROLL, const wxString& name = wxEmptyString );
+
 		~RunProfilesPanel();
 
 		void m_splitter5OnIdle( wxIdleEvent& )
@@ -1808,7 +1829,7 @@ class AlignMoviesPanel : public JobPanel
 		MemoryComboBox* RunProfileComboBox;
 		wxButton* StartAlignmentButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnExpertOptionsToggle( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnInfoURL( wxTextUrlEvent& event ) { event.Skip(); }
@@ -1821,6 +1842,7 @@ class AlignMoviesPanel : public JobPanel
 		MovieGroupPickerComboPanel* GroupComboBox;
 
 		AlignMoviesPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 927,653 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~AlignMoviesPanel();
 
 };
@@ -1961,7 +1983,7 @@ class Refine3DPanel : public JobPanel
 		MemoryComboBox* ReconstructionRunProfileComboBox;
 		wxButton* StartRefinementButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnUseMaskCheckBox( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnHighResLimitChange( wxCommandEvent& event ) { event.Skip(); }
@@ -1981,6 +2003,7 @@ class Refine3DPanel : public JobPanel
 		DisplayRefinementResultsPanel* ShowRefinementResultsPanel;
 
 		Refine3DPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1285,635 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~Refine3DPanel();
 
 };
@@ -2077,7 +2100,7 @@ class RefineCTFPanelParent : public JobPanel
 		MemoryComboBox* ReconstructionRunProfileComboBox;
 		wxButton* StartRefinementButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnUseMaskCheckBox( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnHighResLimitChange( wxCommandEvent& event ) { event.Skip(); }
@@ -2097,6 +2120,7 @@ class RefineCTFPanelParent : public JobPanel
 		DisplayCTFRefinementResultsPanel* ShowRefinementResultsPanel;
 
 		RefineCTFPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1285,635 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~RefineCTFPanelParent();
 
 };
@@ -2160,7 +2184,7 @@ class Sharpen3DPanelParent : public wxPanel
 		wxButton* ImportResultButton;
 		wxButton* SaveResultButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnUseMaskCheckBox( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnAutoMaskButton( wxCommandEvent& event ) { event.Skip(); }
@@ -2174,6 +2198,7 @@ class Sharpen3DPanelParent : public wxPanel
 		VolumeAssetPickerComboPanel* VolumeComboBox;
 
 		Sharpen3DPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1124,1252 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~Sharpen3DPanelParent();
 
 };
@@ -2242,7 +2267,7 @@ class Generate3DPanelParent : public JobPanel
 		MemoryComboBox* ReconstructionRunProfileComboBox;
 		wxButton* StartReconstructionButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnExpertOptionsToggle( wxCommandEvent& event ) { event.Skip(); }
 		virtual void ResetAllDefaultsClick( wxCommandEvent& event ) { event.Skip(); }
@@ -2258,6 +2283,7 @@ class Generate3DPanelParent : public JobPanel
 		DisplayRefinementResultsPanel* ShowRefinementResultsPanel;
 
 		Generate3DPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1285,635 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~Generate3DPanelParent();
 
 };
@@ -2347,7 +2373,7 @@ class AutoRefine3DPanelParent : public JobPanel
 		MemoryComboBox* ReconstructionRunProfileComboBox;
 		wxButton* StartRefinementButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnUseMaskCheckBox( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnExpertOptionsToggle( wxCommandEvent& event ) { event.Skip(); }
@@ -2363,6 +2389,7 @@ class AutoRefine3DPanelParent : public JobPanel
 		DisplayRefinementResultsPanel* ShowRefinementResultsPanel;
 
 		AutoRefine3DPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1216,660 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~AutoRefine3DPanelParent();
 
 };
@@ -2434,7 +2461,7 @@ class FindCTFPanel : public JobPanel
 		MemoryComboBox* RunProfileComboBox;
 		wxButton* StartEstimationButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnExpertOptionsToggle( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnMovieRadioButton( wxCommandEvent& event ) { event.Skip(); }
@@ -2453,6 +2480,7 @@ class FindCTFPanel : public JobPanel
 		ShowCTFResultsPanel* CTFResultsPanel;
 
 		FindCTFPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1200,731 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~FindCTFPanel();
 
 };
@@ -2519,7 +2547,7 @@ class MatchTemplatePanelParent : public JobPanel
 		wxButton* StartEstimationButton;
 		wxCheckBox* ResumeRunCheckBox;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void ResetAllDefaultsClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnInfoURL( wxTextUrlEvent& event ) { event.Skip(); }
@@ -2535,6 +2563,7 @@ class MatchTemplatePanelParent : public JobPanel
 		ShowTemplateMatchResultsPanel* ResultsPanel;
 
 		MatchTemplatePanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1200,731 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~MatchTemplatePanelParent();
 
 };
@@ -2610,7 +2639,7 @@ class RefineTemplatePanelParent : public JobPanel
 		MemoryComboBox* RunProfileComboBox;
 		wxButton* StartEstimationButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void ResetAllDefaultsClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnInfoURL( wxTextUrlEvent& event ) { event.Skip(); }
@@ -2625,6 +2654,7 @@ class RefineTemplatePanelParent : public JobPanel
 		ShowTemplateMatchResultsPanel* ResultsPanel;
 
 		RefineTemplatePanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1200,731 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~RefineTemplatePanelParent();
 
 };
@@ -2701,7 +2731,7 @@ class RefineTemplateDevPanelParent : public JobPanel
 		MemoryComboBox* RunProfileComboBox;
 		wxButton* StartEstimationButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void ResetAllDefaultsClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnInfoURL( wxTextUrlEvent& event ) { event.Skip(); }
@@ -2715,6 +2745,7 @@ class RefineTemplateDevPanelParent : public JobPanel
 		ShowTemplateMatchResultsPanel* ResultsPanel;
 
 		RefineTemplateDevPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1200,731 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~RefineTemplateDevPanelParent();
 
 };
@@ -2736,7 +2767,7 @@ class NewProjectWizard : public wxWizard
 		wxTextCtrl* ProjectPathTextCtrl;
 		wxStaticText* ErrorText;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnFinished( wxWizardEvent& event ) { event.Skip(); }
 		virtual void OnProjectTextChange( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnParentDirChange( wxCommandEvent& event ) { event.Skip(); }
@@ -2748,6 +2779,7 @@ class NewProjectWizard : public wxWizard
 
 		NewProjectWizard( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Create New Project"), const wxBitmap& bitmap = wxNullBitmap, const wxPoint& pos = wxDefaultPosition, long style = wxDEFAULT_DIALOG_STYLE );
 		WizardPages m_pages;
+
 		~NewProjectWizard();
 
 };
@@ -2779,7 +2811,7 @@ class ExportRefinementPackageWizardParent : public wxWizard
 		wxTextCtrl* MetaDataFileTextCtrl;
 		wxButton* m_button242;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnFinished( wxWizardEvent& event ) { event.Skip(); }
 		virtual void OnPageChanged( wxWizardEvent& event ) { event.Skip(); }
@@ -2793,6 +2825,7 @@ class ExportRefinementPackageWizardParent : public wxWizard
 
 		ExportRefinementPackageWizardParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString, const wxBitmap& bitmap = wxNullBitmap, const wxPoint& pos = wxDefaultPosition, long style = wxDEFAULT_DIALOG_STYLE );
 		WizardPages m_pages;
+
 		~ExportRefinementPackageWizardParent();
 
 };
@@ -2835,7 +2868,7 @@ class ImportRefinementPackageWizardParent : public wxWizard
 		wxRadioButton* BlackProteinRadioButton;
 		wxRadioButton* WhiteProteinRadioButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnFinished( wxWizardEvent& event ) { event.Skip(); }
 		virtual void OnPageChanged( wxWizardEvent& event ) { event.Skip(); }
@@ -2852,6 +2885,7 @@ class ImportRefinementPackageWizardParent : public wxWizard
 
 		ImportRefinementPackageWizardParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString, const wxBitmap& bitmap = wxNullBitmap, const wxPoint& pos = wxDefaultPosition, long style = wxDEFAULT_DIALOG_STYLE );
 		WizardPages m_pages;
+
 		~ImportRefinementPackageWizardParent();
 
 };
@@ -2874,7 +2908,7 @@ class AddRunCommandDialog : public wxDialog
 		wxButton* OKButton;
 		wxButton* CancelButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnEnter( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnOverrideCheckbox( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnOKClick( wxCommandEvent& event ) { event.Skip(); }
@@ -2890,6 +2924,7 @@ class AddRunCommandDialog : public wxDialog
 		wxSpinCtrl* OverridenNoCopiesSpinCtrl;
 
 		AddRunCommandDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Enter Command..."), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( -1,-1 ), long style = wxDEFAULT_DIALOG_STYLE );
+
 		~AddRunCommandDialog();
 
 };
@@ -2910,7 +2945,7 @@ class RenameDialog : public wxDialog
 		wxButton* CancelButton;
 		wxButton* RenameButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnCancelClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnRenameClick( wxCommandEvent& event ) { event.Skip(); }
 
@@ -2919,6 +2954,7 @@ class RenameDialog : public wxDialog
 		wxBoxSizer* RenameBoxSizer;
 
 		RenameDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Rename Assets"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_DIALOG_STYLE );
+
 		~RenameDialog();
 
 };
@@ -2932,7 +2968,7 @@ class NewRefinementPackageWizard : public wxWizard
 
 	protected:
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnFinished( wxWizardEvent& event ) { event.Skip(); }
 		virtual void PageChanged( wxWizardEvent& event ) { event.Skip(); }
 		virtual void PageChanging( wxWizardEvent& event ) { event.Skip(); }
@@ -2942,6 +2978,7 @@ class NewRefinementPackageWizard : public wxWizard
 
 		NewRefinementPackageWizard( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Create New Refinement Package"), const wxBitmap& bitmap = wxNullBitmap, const wxPoint& pos = wxDefaultPosition, long style = wxDEFAULT_DIALOG_STYLE );
 		WizardPages m_pages;
+
 		~NewRefinementPackageWizard();
 
 };
@@ -2961,7 +2998,7 @@ class VolumeChooserDialog : public wxDialog
 		wxButton* CancelButton;
 		wxButton* SetButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnCancelClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnRenameClick( wxCommandEvent& event ) { event.Skip(); }
 
@@ -2970,6 +3007,7 @@ class VolumeChooserDialog : public wxDialog
 		VolumeAssetPickerComboPanel* ComboBox;
 
 		VolumeChooserDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Select new reference"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( -1,-1 ), long style = wxDEFAULT_DIALOG_STYLE );
+
 		~VolumeChooserDialog();
 
 };
@@ -2989,7 +3027,7 @@ class AtomicCoordinatesChooserDialogParent : public wxDialog
 		wxButton* CancelButton;
 		wxButton* SetButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnCancelClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnRenameClick( wxCommandEvent& event ) { event.Skip(); }
 
@@ -2998,6 +3036,7 @@ class AtomicCoordinatesChooserDialogParent : public wxDialog
 		VolumeAssetPickerComboPanel* ComboBox;
 
 		AtomicCoordinatesChooserDialogParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Select new reference"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( -1,-1 ), long style = wxDEFAULT_DIALOG_STYLE );
+
 		~AtomicCoordinatesChooserDialogParent();
 
 };
@@ -3022,7 +3061,7 @@ class FilterDialog : public wxDialog
 		wxButton* CancelButton;
 		wxButton* FilterButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnCancelClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnFilterClick( wxCommandEvent& event ) { event.Skip(); }
 
@@ -3031,6 +3070,7 @@ class FilterDialog : public wxDialog
 		wxStaticText* m_staticText81;
 
 		FilterDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Filter / Sort Movies"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_DIALOG_STYLE );
+
 		~FilterDialog();
 
 };
@@ -3050,7 +3090,7 @@ class ParticlePositionExportDialog : public wxDialog
 		wxButton* CancelButton;
 		wxButton* ExportButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnDirChanged( wxFileDirPickerEvent& event ) { event.Skip(); }
 		virtual void OnCancelButtonClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnExportButtonClick( wxCommandEvent& event ) { event.Skip(); }
@@ -3059,6 +3099,7 @@ class ParticlePositionExportDialog : public wxDialog
 	public:
 
 		ParticlePositionExportDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Export particle positions"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( -1,-1 ), long style = wxDEFAULT_DIALOG_STYLE );
+
 		~ParticlePositionExportDialog();
 
 };
@@ -3084,7 +3125,7 @@ class FrealignExportDialog : public wxDialog
 		wxButton* CancelButton;
 		wxButton* ExportButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnFlipCTFCheckBox( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnOutputImageStackFileChanged( wxFileDirPickerEvent& event ) { event.Skip(); }
 		virtual void OnCancelButtonClick( wxCommandEvent& event ) { event.Skip(); }
@@ -3094,6 +3135,7 @@ class FrealignExportDialog : public wxDialog
 	public:
 
 		FrealignExportDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Export to Frealign"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( -1,-1 ), long style = wxDEFAULT_DIALOG_STYLE );
+
 		~FrealignExportDialog();
 
 };
@@ -3122,7 +3164,7 @@ class RelionExportDialog : public wxDialog
 		wxButton* CancelButton;
 		wxButton* ExportButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnNormalizeCheckBox( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnFlipCTFCheckBox( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnOutputImageStackFileChanged( wxFileDirPickerEvent& event ) { event.Skip(); }
@@ -3133,6 +3175,7 @@ class RelionExportDialog : public wxDialog
 	public:
 
 		RelionExportDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Export to Relion"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( -1,-1 ), long style = wxDEFAULT_DIALOG_STYLE );
+
 		~RelionExportDialog();
 
 };
@@ -3180,7 +3223,7 @@ class RefinementPackageAssetPanel : public wxPanel
 		wxStaticText* m_staticText212;
 		wxStaticText* LastRefinementIDText;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpdateUI( wxUpdateUIEvent& event ) { event.Skip(); }
 		virtual void OnCreateClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnRenameClick( wxCommandEvent& event ) { event.Skip(); }
@@ -3201,6 +3244,7 @@ class RefinementPackageAssetPanel : public wxPanel
 	public:
 
 		RefinementPackageAssetPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 770,428 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~RefinementPackageAssetPanel();
 
 		void m_splitter11OnIdle( wxIdleEvent& )
@@ -3226,6 +3270,7 @@ class TemplateWizardPanel : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		TemplateWizardPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~TemplateWizardPanel();
 
 };
@@ -3245,6 +3290,7 @@ class InputParameterWizardPanel : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		InputParameterWizardPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~InputParameterWizardPanel();
 
 };
@@ -3264,6 +3310,7 @@ class ClassSelectionWizardPanel : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		ClassSelectionWizardPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~ClassSelectionWizardPanel();
 
 };
@@ -3283,6 +3330,7 @@ class SymmetryWizardPanel : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		SymmetryWizardPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~SymmetryWizardPanel();
 
 };
@@ -3302,6 +3350,7 @@ class MolecularWeightWizardPanel : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		MolecularWeightWizardPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~MolecularWeightWizardPanel();
 
 };
@@ -3324,6 +3373,7 @@ class InitialReferenceSelectWizardPanel : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		InitialReferenceSelectWizardPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~InitialReferenceSelectWizardPanel();
 
 };
@@ -3343,6 +3393,7 @@ class LargestDimensionWizardPanel : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		LargestDimensionWizardPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~LargestDimensionWizardPanel();
 
 };
@@ -3362,6 +3413,7 @@ class OutputPixelSizeWizardPanel : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		OutputPixelSizeWizardPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~OutputPixelSizeWizardPanel();
 
 };
@@ -3381,6 +3433,7 @@ class ParticleGroupWizardPanel : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		ParticleGroupWizardPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~ParticleGroupWizardPanel();
 
 };
@@ -3400,6 +3453,7 @@ class BoxSizeWizardPanel : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		BoxSizeWizardPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~BoxSizeWizardPanel();
 
 };
@@ -3419,6 +3473,7 @@ class NumberofClassesWizardPanel : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		NumberofClassesWizardPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~NumberofClassesWizardPanel();
 
 };
@@ -3439,6 +3494,7 @@ class ClassesSetupWizardPanelA : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		ClassesSetupWizardPanelA( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~ClassesSetupWizardPanelA();
 
 };
@@ -3459,6 +3515,7 @@ class RecentrePicksWizardPanel : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		RecentrePicksWizardPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~RecentrePicksWizardPanel();
 
 };
@@ -3479,6 +3536,7 @@ class RemoveDuplicatesWizardPanel : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		RemoveDuplicatesWizardPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~RemoveDuplicatesWizardPanel();
 
 };
@@ -3498,6 +3556,7 @@ class RemoveDuplicateThresholdWizardPanel : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		RemoveDuplicateThresholdWizardPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~RemoveDuplicateThresholdWizardPanel();
 
 };
@@ -3518,6 +3577,7 @@ class ClassesSetupWizardPanelB : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		ClassesSetupWizardPanelB( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~ClassesSetupWizardPanelB();
 
 };
@@ -3539,6 +3599,7 @@ class ClassesSetupWizardPanelC : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		ClassesSetupWizardPanelC( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~ClassesSetupWizardPanelC();
 
 };
@@ -3559,6 +3620,7 @@ class ClassesSetupWizardPanelD : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		ClassesSetupWizardPanelD( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~ClassesSetupWizardPanelD();
 
 };
@@ -3579,6 +3641,7 @@ class ClassesSetupWizardPanelE : public wxPanel
 		AutoWrapStaticText* InfoText;
 
 		ClassesSetupWizardPanelE( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 600,400 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~ClassesSetupWizardPanelE();
 
 };
@@ -3599,7 +3662,7 @@ class FSCPanel : public wxPanel
 		wxStaticLine* m_staticline52;
 		PlotFSCPanel* PlotPanel;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void SaveImageClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void PopupTextClick( wxCommandEvent& event ) { event.Skip(); }
 
@@ -3609,6 +3672,7 @@ class FSCPanel : public wxPanel
 		NoFocusBitmapButton* FSCDetailsButton;
 
 		FSCPanel( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 500,300 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~FSCPanel();
 
 };
@@ -3627,6 +3691,7 @@ class DisplayPanelParent : public wxPanel
 	public:
 
 		DisplayPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 500,300 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~DisplayPanelParent();
 
 };
@@ -3654,7 +3719,7 @@ class DisplayManualDialogParent : public wxDialog
 		wxButton* m_button94;
 		wxButton* m_button95;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnClose( wxCloseEvent& event ) { event.Skip(); }
 		virtual void OnLeftDown( wxMouseEvent& event ) { event.Skip(); }
 		virtual void OnMotion( wxMouseEvent& event ) { event.Skip(); }
@@ -3671,6 +3736,7 @@ class DisplayManualDialogParent : public wxDialog
 	public:
 
 		DisplayManualDialogParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("Manual Grey Settings"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_DIALOG_STYLE );
+
 		~DisplayManualDialogParent();
 
 };
@@ -3691,6 +3757,7 @@ class ClassificationPlotPanelParent : public wxPanel
 		wxAuiNotebook* my_notebook;
 
 		ClassificationPlotPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 500,300 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~ClassificationPlotPanelParent();
 
 };
@@ -3709,6 +3776,7 @@ class AbInitioPlotPanelParent : public wxPanel
 		wxAuiNotebook* my_notebook;
 
 		AbInitioPlotPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 500,300 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~AbInitioPlotPanelParent();
 
 };
@@ -3728,7 +3796,7 @@ class ClassumSelectionCopyFromDialogParent : public wxDialog
 		wxButton* OkButton;
 		wxButton* CancelButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnOKButtonClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnCancelButtonClick( wxCommandEvent& event ) { event.Skip(); }
 
@@ -3736,6 +3804,7 @@ class ClassumSelectionCopyFromDialogParent : public wxDialog
 	public:
 
 		ClassumSelectionCopyFromDialogParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( -1,-1 ), long style = wxDEFAULT_DIALOG_STYLE );
+
 		~ClassumSelectionCopyFromDialogParent();
 
 };
@@ -3752,7 +3821,7 @@ class ErrorDialog : public wxDialog
 		wxStaticText* m_staticText25;
 		wxButton* m_button23;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnClickOK( wxCommandEvent& event ) { event.Skip(); }
 
 
@@ -3760,6 +3829,7 @@ class ErrorDialog : public wxDialog
 		wxTextCtrl* ErrorText;
 
 		ErrorDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 514,500 ), long style = wxDEFAULT_DIALOG_STYLE );
+
 		~ErrorDialog();
 
 };
@@ -3796,6 +3866,7 @@ class UnblurResultsPanelParent : public wxPanel
 		DisplayPanel* ImageDisplayPanel;
 
 		UnblurResultsPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 698,300 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~UnblurResultsPanelParent();
 
 		void m_splitter13OnIdle( wxIdleEvent& )
@@ -3827,6 +3898,7 @@ class ListCtrlDialog : public wxDialog
 		AssetPickerListCtrl* MyListCtrl;
 
 		ListCtrlDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_DIALOG_STYLE );
+
 		~ListCtrlDialog();
 
 };
@@ -3857,6 +3929,7 @@ class DisplayRefinementResultsPanelParent : public wxPanel
 		wxPanel* RoundPlotPanel;
 
 		DisplayRefinementResultsPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 952,539 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~DisplayRefinementResultsPanelParent();
 
 		void LeftRightSplitterOnIdle( wxIdleEvent& )
@@ -3899,6 +3972,7 @@ class DisplayCTFRefinementResultsPanelParent : public wxPanel
 		wxPanel* RoundPlotPanel;
 
 		DisplayCTFRefinementResultsPanelParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 952,539 ), long style = wxTAB_TRAVERSAL, const wxString& name = wxEmptyString );
+
 		~DisplayCTFRefinementResultsPanelParent();
 
 		void LeftRightSplitterOnIdle( wxIdleEvent& )
@@ -3927,7 +4001,7 @@ class PopupTextDialogParent : public wxDialog
 		wxButton* ClipBoardButton;
 		wxButton* m_button146;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnCloseButtonClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnCopyToClipboardClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnSaveButtonClick( wxCommandEvent& event ) { event.Skip(); }
@@ -3937,6 +4011,7 @@ class PopupTextDialogParent : public wxDialog
 		wxTextCtrl* OutputTextCtrl;
 
 		PopupTextDialogParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxCAPTION|wxCLOSE_BOX|wxRESIZE_BORDER );
+
 		~PopupTextDialogParent();
 
 };
@@ -3953,7 +4028,7 @@ class LargeAngularPlotDialogParent : public wxDialog
 		wxButton* ClipBoardButton;
 		wxButton* SaveButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnCloseButtonClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnCopyToClipboardClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnSaveButtonClick( wxCommandEvent& event ) { event.Skip(); }
@@ -3963,6 +4038,7 @@ class LargeAngularPlotDialogParent : public wxDialog
 		AngularDistributionPlotPanel* AngularPlotPanel;
 
 		LargeAngularPlotDialogParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1000,800 ), long style = wxCAPTION|wxCLOSE_BOX|wxRESIZE_BORDER );
+
 		~LargeAngularPlotDialogParent();
 
 };
@@ -3982,7 +4058,7 @@ class RefinementParametersDialogParent : public wxDialog
 		wxButton* CloseButton;
 		wxButton* SaveButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnCloseButtonClick( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnSaveButtonClick( wxCommandEvent& event ) { event.Skip(); }
 
@@ -3990,6 +4066,7 @@ class RefinementParametersDialogParent : public wxDialog
 	public:
 
 		RefinementParametersDialogParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 1000,800 ), long style = wxCAPTION|wxCLOSE_BOX|wxRESIZE_BORDER );
+
 		~RefinementParametersDialogParent();
 
 };
@@ -4026,6 +4103,7 @@ class AboutDialog : public wxDialog
 		wxStaticText* BuildDateText;
 
 		AboutDialog( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxT("About cisTEM"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_DIALOG_STYLE );
+
 		~AboutDialog();
 
 };
@@ -4050,7 +4128,7 @@ class DistributionPlotDialogParent : public wxDialog
 		wxButton* SaveTXTButton;
 		wxButton* SavePNGButton;
 
-		// Virtual event handlers, overide them in your derived class
+		// Virtual event handlers, override them in your derived class
 		virtual void OnUpperBoundYKillFocus( wxFocusEvent& event ) { event.Skip(); }
 		virtual void OnUpperBoundYSetFocus( wxFocusEvent& event ) { event.Skip(); }
 		virtual void OnUpperBoundYTextEnter( wxCommandEvent& event ) { event.Skip(); }
@@ -4072,6 +4150,7 @@ class DistributionPlotDialogParent : public wxDialog
 		PlotCurvePanel* PlotCurvePanelInstance;
 
 		DistributionPlotDialogParent( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = wxEmptyString, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxSize( 575,462 ), long style = wxDEFAULT_DIALOG_STYLE );
+
 		~DistributionPlotDialogParent();
 
 };


### PR DESCRIPTION
# Description

This adds a Volume combo box to the RefineTemplateResultsPanel, which then only lists results from the selected reference.


https://user-images.githubusercontent.com/6081039/163870207-b846f794-e106-4cc8-b700-f052fea62018.mp4

It also:

- Creates a backup of the DB everytime a project is opened
- Updates the wxFormBuilder project 


Fixes # (issue)

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [ ] yes
- [ ] no

# Which compilers were tested

- [x] g++
- [ ] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [x] gui
- [ ] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- x] Tested manually from GUI
- [ ] Tested manually from CLI
- [ ] Passed console tests
- [ ] Passed samples functional testing
- [ ] other (please specify)

# Checklist:

- [ ] I have not changed anything that did not need to be changed
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
