### PR TITLE
Enforces linking to the MKL as FFTW3 would cause license conflicts.

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -2,7 +2,7 @@
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.230.0/containers/ubuntu
 {
     // "name": "cisTEMx-0.1",
-    "image": "bhimesbhimes/cistem_build_env:v1.1",
+    "image": "bhimesbhimes/cistem_build_env:v1.2",
     // Set *default* container specific settings.json values on container create.
     "settings": {},
     // Add the IDs of extensions you want installed when the container is created.

--- a/.devcontainer_build/Dockerfile
+++ b/.devcontainer_build/Dockerfile
@@ -31,6 +31,20 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y libgtk2.0-de
     && rm -rf /var/lib/apt/lists/*
 
 
+# Get the MKL: note, this is 4.4G by default, will try to determine minimal set needed
+RUN wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+RUN echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+RUN apt-get update && apt-get install -y intel-oneapi-mkl-devel \
+    && rm -rf /var/lib/apt/lists/*
+
+# Minimize the MKL disk footprint
+RUN cd  /opt/intel/oneapi/mkl/latest/lib/intel64/ && \
+    rm -f *.a libmkl_sycl*
+
+RUN echo 'alias lt="ls -lrth"' >> /home/cisTEMx/.bashrc
+RUN echo 'alias dU="du -ch --max-depth=1 | sort -h"' >> /home/cisTEMx/.bashrc
+RUN echo 'source /opt/intel/oneapi/setvars.sh' >> /home/cisTEMx/.bashrc
+RUN echo 'bind "set bell-style none"' >> /home/cisTEMx/.bashrc
 
 # wx Formbuilder deps For focal
 # wxWidgets with gtk3 compiles fine but has weird sizing issues. Can prob be sorted easily, but for now, stick with 2.
@@ -95,8 +109,12 @@ RUN echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main" | tee -a 
     echo "deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main" | tee -a /etc/apt/sources.list
 
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-RUN apt-get update && apt-get install clang-format-14 -y && \
-    cd /usr/bin && ln -s clang-format-14 clang-format
+RUN apt-get update && apt-get install -y clang-format-14 -y && \
+    cd /usr/bin && ln -s clang-format-14 clang-format \
+    && rm -rf /var/lib/apt/lists/*
+
+
 
 USER cisTEMx
 WORKDIR /home/cisTEMx
+

--- a/.devcontainer_build/Dockerfile
+++ b/.devcontainer_build/Dockerfile
@@ -41,6 +41,9 @@ RUN apt-get update && apt-get install -y intel-oneapi-mkl-devel \
 RUN cd  /opt/intel/oneapi/mkl/latest/lib/intel64/ && \
     rm -f *.a libmkl_sycl*
 
+# Set the MKL related variables
+ENTRYPOINT ["/bin/bash","-c","source /opt/intel/oneapi/setvars.sh"]
+
 RUN echo 'alias lt="ls -lrth"' >> /home/cisTEMx/.bashrc
 RUN echo 'alias dU="du -ch --max-depth=1 | sort -h"' >> /home/cisTEMx/.bashrc
 RUN echo 'source /opt/intel/oneapi/setvars.sh' >> /home/cisTEMx/.bashrc

--- a/.github/FFT_LICENSE_NOTE
+++ b/.github/FFT_LICENSE_NOTE
@@ -1,0 +1,12 @@
+cisTEM is written to be compatible with the open source, GPL version2 licensed FFTW3 libraries, without actually using those libraries.
+We wish to maintain the more permissive licensing, with a selected limit being the Mozilla version2 license, that applies copy left on a file by file basis.
+
+You must link to the, free to use Intel MKL FFT routines, which are distributed with the permissive Intel Simplified License. 
+
+Note that a version of fftw3.h is used that is distributed with the Intel MKL, by permission granted to that organization. We do not link to any FFTW3 libraries, or files distributed with them, and hence are not subject to the GPL version2 license.
+
+We do support the open sharing of software, and if for you this means accepting the terms of the GNU GPL, and you wish to use FFTW3, you are free to create your own derivative work based on the cisTEM project and remove the precompiled guards. Each of these is prefaced with a comment to facilitate this process. // LINK_MKL_NOT_FFTW3 (or # LINK_MKL_NOT_FFTW3). 
+
+You must be aware that the GNU GPL is not compatible with other licenses the cisTEM project may use through third party libraries.
+
+If you decide to create a derivative work, it is then entirely your responsibility to ensure only libraries with compliant licenses are included. In particular, but not strictly limited to, certain proprietary libraries from Nvidia explicitly forbid being made subject to any GPL licenses, and you must, in such derivative work, remove these dependencies. The authors and contributors of the cisTEM project are not to be held liable for any mistakes made by creators of such a derivative work. Nor are the authors or contributors of the cisTEM project to be held liable for any damages caused by such a derivative work. Finally, it shall be understood that any such endeavour to create a derivative work is at your own risk, and you will receive no advice, support, or warranty from the authors or contributors of the cisTEM project.

--- a/.github/workflows/run_builds.yml
+++ b/.github/workflows/run_builds.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: source_mkl
-      run: source /opt/intel/oneapi/setvars.sh
+      run: . /opt/intel/oneapi/setvars.sh
     - name: regenerate_project
       run: ./regenerate_project.b
     - name: configure

--- a/.github/workflows/run_builds.yml
+++ b/.github/workflows/run_builds.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: true
     runs-on: ${{ inputs.runs_on_os }}
     container: 
-      image: bhimesbhimes/cistem_build_env:v1.1
+      image: bhimesbhimes/cistem_build_env:v1.2
       options: --user root
     outputs:
       version: ${{ steps.configure.outputs.version }}

--- a/.github/workflows/run_builds.yml
+++ b/.github/workflows/run_builds.yml
@@ -32,8 +32,6 @@ jobs:
       # the macro for CISTEM_VERSION_TEXT needs access to the history.
       with:
         fetch-depth: 0
-    - name: source_mkl
-      run: . /opt/intel/oneapi/setvars.sh
     - name: regenerate_project
       run: ./regenerate_project.b
     - name: configure
@@ -41,6 +39,7 @@ jobs:
         CC: gcc
         CXX: g++
       run: |
+        . /opt/intel/oneapi/setvars.sh
         mkdir -p build/${{ inputs.build_type }} 
         cd build/${{ inputs.build_type }} 
         echo $CC

--- a/.github/workflows/run_builds.yml
+++ b/.github/workflows/run_builds.yml
@@ -66,6 +66,7 @@ jobs:
 
     - name: Console test
       run: |
+        . /opt/intel/oneapi/setvars.sh
         cd build/${{ inputs.build_type }}/src
         chmod +x *
         ./console_test 
@@ -74,6 +75,7 @@ jobs:
     # chmod is redundant, but to keep this independent of Console test we keep it.
     - name: Samples functional testing
       run: |
+        . /opt/intel/oneapi/setvars.sh
         cd build/${{ inputs.build_type }}/src 
         chmod +x samples_functional_testing
         ./samples_functional_testing
@@ -81,6 +83,7 @@ jobs:
     # chmod is redundant, but to keep this independent of Console test we keep it.
     - name: Unit tests
       run: |
+        . /opt/intel/oneapi/setvars.sh
         cd build/${{ inputs.build_type }}/src 
         chmod +x unit_test_runner
         ./unit_test_runner

--- a/.github/workflows/run_builds.yml
+++ b/.github/workflows/run_builds.yml
@@ -32,6 +32,8 @@ jobs:
       # the macro for CISTEM_VERSION_TEXT needs access to the history.
       with:
         fetch-depth: 0
+    - name: source_mkl
+      run: source /opt/intel/oneapi/setvars.sh
     - name: regenerate_project
       run: ./regenerate_project.b
     - name: configure

--- a/.vscode_shared/BenHimes/tasks.json
+++ b/.vscode_shared/BenHimes/tasks.json
@@ -89,7 +89,7 @@
         {
             "label": "CONFIG GNU ,gpu",
             "type": "shell",
-            "command": "mkdir -p ${build_dir}/GNU-gpu && cd ${build_dir}/GNU-gpu && CC=gcc CXX=g++ ../../configure --enable-samples --disable-mkl --enable-experimental --with-cuda=/usr/local/cuda --disable-staticmode --enable-openmp"
+            "command": "mkdir -p ${build_dir}/GNU-gpu && cd ${build_dir}/GNU-gpu && CC=gcc CXX=g++ ../../configure --enable-samples --enable-experimental --with-cuda=/usr/local/cuda --disable-staticmode --enable-openmp"
         },
         {
             "label": "BUILD GNU,gpu",

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,7 @@ AC_CONFIG_MACRO_DIR([m4])
 INPUT_CPPFLAGS="$CPPFLAGS"
 INPUT_CXXFLAGS="$CXXFLAGS"
 
+
 AC_PROG_CC([icc gcc clang])
 AC_PROG_CXX([icpc g++ clang++])
 
@@ -147,12 +148,14 @@ fi
 # MKL
 
 use_mkl=1
-AC_ARG_ENABLE(mkl, AS_HELP_STRING([--disable-mkl],[Do not use the Intel MKL]),
-[
+AC_ARG_ENABLE(mkl, AS_HELP_STRING([--disable-mkl],[Do not use the Intel MKL]), [
  if test "$enableval" = no; then
-        use_mkl=0
+    # LINK_MKL_NOT_FFTW3
+    AC_MSG_NOTICE([     ])
+    AC_MSG_ERROR([You must use the Intel mkl in cisTEM. See FFT_LICENSE_NOTE in the root directory for details.])
+    use_mkl=0
  fi
- ])
+])
 
 
 # Static linking
@@ -163,7 +166,7 @@ AC_ARG_ENABLE(staticmode, AS_HELP_STRING([--enable-staticmode],[Link statically 
 	static_link="true"
 	WXCONFIGFLAGS="--static=yes"
   fi
-  ])
+])
 
 	
 AC_MSG_NOTICE(static_link = $static_link)
@@ -385,39 +388,105 @@ else
         wx_is_available=0
 fi
 
-# Do FFTW3 Checks
+# Link the MKL with a variety of threading options
 
-# Check whether Intel's MKL is available. If not, link against FFTW.
+use_mkl_threads="no"
+use_gnu_threads="no"
+use_mkl_sequential="yes"
+AC_ARG_ENABLE(mkl-threads, AS_HELP_STRING([--enable-mkl-threads],[Compile with MKL threading using Intel threads [default=no]]),[
+    use_mkl_threads="yes"
+    use_mkl_sequential="no"
+
+])
+AC_ARG_ENABLE(gnu-threads, AS_HELP_STRING([--enable-gnu-threads],[Compile with MKL threading using Intel threads [default=no]]),[
+    use_gnu_threads="yes"
+    use_mkl_sequential="no"
+
+])
+
+# Make sure we have the environmental variables set up
+AC_CHECK_FILE("$MKLROOT/include/mkl.h",
+[   ],
+[AC_MSG_ERROR([MKLROOT is not set correctly])
+])
+
+# Compiler options are the same for all threading options (as long as it is gcc)
+AC_DEFINE([MKL_ILP64], [], [Use the MKL ILP64 interface])
+CPPFLAGS="$CPPFLAGS -m64 -I"${MKLROOT}/include""
+CXXFLAGS="$CXXFLAGS -m64 -I"${MKLROOT}/include""
+LDFLAGS="$LDFLAGS -L"${MKLROOT}/lib/intel64""
+
+if test "x$use_mkl_threads" = "xyes" -o "x$use_gnu_threads" = "xyes"; then
+
+    # I added the proper options here along when updating with sequential, which is what cisTEM has always used.
+    # To actually use threaded FFTs, we would need to:
+    # For multithreaded plans, use normal sequence of calls to the fftw_init_threads() and fftw_plan_with_nthreads() functions (refer to FFTW documentation).
+    AC_MSG_NOTICE([      ]) 
+    AC_MSG_ERROR([ Threading with the MKL is not fully supported yet. ])
+    # We can't have both mkl-threads and gnu-threads
+    if test "x$use_mkl_threads" = "xyes" -a "x$use_gnu_threads" = "xyes"; then
+        AC_MSG_ERROR("You can't have both --enable-mkl-threads and --enable-gnu-threads")
+    fi
+
+    # Okay, we have only one of them, so we can use the mkl-threads or gnu-threads
+    if test "x$use_mkl_threads" = "xyes"; then
+        if test "x$static_link" = "xtrue" ; then          
+            LIBS="$LIBS -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_ilp64.a 
+${MKLROOT}/lib/intel64/libmkl_core.a -Wl,--end-group -liomp5 -lpthread -lm -ldl ${MKLROOT}/lib/intel64/libmkl_intel_thread.a"
+        else
+            LIBS="$LIBS -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_intel_thread -lmkl_core -liomp5 -lpthread -lm -ldl"
+        fi
+    else
+        if test "x$static_link" = "xtrue" ; then
+            LIBS="$LIBS -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_ilp64.a 
+${MKLROOT}/lib/intel64/libmkl_core.a -Wl,--end-group -lgomp -lpthread -lm -ldl ${MKLROOT}/lib/intel64/libmkl_gnu_thread.a"
+        else
+            LIBS="$LIBS -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl"
+        fi
+    fi
+else    
+    # Use MKL seqential
+    AC_MSG_NOTICE([   Using the MKL sequential interface. ])
+    if test "x$static_link" = "xtrue" ; then
+        LIBS="$LIBS -Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_ilp64.a 
+${MKLROOT}/lib/intel64/libmkl_core.a -Wl,--end-group -lpthread -lm -ldl ${MKLROOT}/lib/intel64/libmkl_sequential.a"
+    else
+        LIBS="$LIBS -Wl,--no-as-needed -lmkl_intel_ilp64 -lmkl_sequential -lmkl_core -lpthread -lm -ldl"
+    fi    
+fi
+
+
+# Even though we do not link the FFTW3 libraries, the Intel MKL uses one of FFTW3's headers to maintain parity while defining a wrapper. 
 AC_CHECK_HEADER(fftw3.h, , AC_MSG_ERROR("Can't find fftw3.h"))
-AC_CHECK_LIB([mkl_intel_lp64],[fftwf_malloc],[HAVE_MKL="yes"],[HAVE_MKL="no"],[-lmkl_core -lmkl_sequential -lpthread])
+# AC_CHECK_LIB([mkl_intel_lp64],[fftwf_malloc],[HAVE_MKL="yes"],[HAVE_MKL="no"],[-lmkl_core -lmkl_sequential -lpthread])
 
-if test "x$use_mkl" = "x0"; then
-	HAVE_MKL="no"
-fi
+# if test "x$use_mkl" = "x0"; then
+# 	HAVE_MKL="no"
+# fi
 
-if test "x$HAVE_MKL" = "xyes"; then
+# if test "x$HAVE_MKL" = "xyes"; then
 
-	AC_MSG_NOTICE(Using Intel MKL for fast Fourier transforms)
-	AC_DEFINE([MKL], [], [Use the MKL])
+# 	AC_MSG_NOTICE(Using Intel MKL for fast Fourier transforms)
+    AC_DEFINE([MKL], [], [Use the MKL])
 
-	if test "x$CXX" = "xicpc"; then
-		CPPFLAGS="$CPPFLAGS -mkl=sequential"
-		LIBS="$LIBS -mkl=sequential"
-	else
-		LDFLAGS="$LDFLAGS -L\$(MKLROOT)/lib/intel64"
-		if test "x$static_link" = "xtrue"; then
-			AC_MSG_ERROR("Static builds with Intel MKL are not supported when using the GNU compiler. Please try with the Intel compiler instead.")
-	    else
-#	    	LIBS="$LIBS -lmkl_rt"
-	    	LIBS="$LIBS -lmkl_sequential -lmkl_core -lmkl_intel_lp64"
-	    fi
-	fi
-else
+# 	if test "x$CXX" = "xicpc"; then
+# 		CPPFLAGS="$CPPFLAGS -mkl=sequential"
+# 		LIBS="$LIBS -mkl=sequential"
+# 	else
+# 		LDFLAGS="$LDFLAGS -L\$(MKLROOT)/lib/intel64"
+# 		if test "x$static_link" = "xtrue"; then
+# 			AC_MSG_ERROR("Static builds with Intel MKL are not supported when using the GNU compiler. Please try with the Intel compiler instead.")
+# 	    else
+# #	    	LIBS="$LIBS -lmkl_rt"
+# 	    	LIBS="$LIBS -lmkl_sequential -lmkl_core -lmkl_intel_lp64"
+# 	    fi
+# 	fi
+# else
 
-	AC_CHECK_LIB(fftw3f, fftwf_malloc, [LIBS="$LIBS -lfftw3f"],AC_MSG_ERROR("Can't find FFTW3's libraries. Please check your installation of FFTW3."))
-	AC_MSG_NOTICE(Using FFTW for Fourier transforms)
+# 	AC_CHECK_LIB(fftw3f, fftwf_malloc, [LIBS="$LIBS -lfftw3f"],AC_MSG_ERROR("Can't find FFTW3's libraries. Please check your installation of FFTW3."))
+# 	AC_MSG_NOTICE(Using FFTW for Fourier transforms)
 
-fi
+# fi
 
 #If we're goind a static build with the intel compiler, let's have Intel libraries linked statically also
 # It's importnat that -static-intel be specified after -mkl, otherwise mkl will be linked dynamically

--- a/scripts/cisTEM_singularity_dev.def
+++ b/scripts/cisTEM_singularity_dev.def
@@ -1,0 +1,72 @@
+Bootstrap: docker
+From: bhimesbhimes/cistem_build_env:v1.2
+Stage: build
+
+%setup
+#    mkdir ${SINGULARITY_ROOTFS}/cisTEM
+
+%help
+    This container is build to run cisTEM on ubuntu 20.04. The Linux kernel in older distros (e.g. CentOS 6) will not support this container.
+
+    This encapsulates a developmental version of cisTEM that comes with no warrantee and no support. We're happy that you want to try the latest and greatest, and welcome your feedback, but make no promise to chase bugs.
+
+    The source code can be found on github, commit b50d965a56c089488485b45c7431e19dcb038cb1.
+
+    Remember the --nv flag if you plan to use GPUs in template matching
+
+    singularity exec --nv /cisTEM/bin/match_template
+
+%files
+#    /groups/himesb/cisTEM_downstream_bah/build/INTEL-gpu/src/* /cisTEM/bin
+#    /groups/himesb/testGPU_k3image_rot.mrc /cisTEM
+#    /groups/himesb/testGPU_ref.mrc /cisTEM
+
+%environment
+    alias lt='ls -lrth'
+#    alias dU='du -ch --max-depth=1 | sort -h'
+  export othertest="otherone"
+
+%post
+    apt-get update && apt-get install -y libfftw3-dev pkg-config libgtk2.0-dev
+
+    NOW=`date`
+    echo "export NOW=\"${NOW}\"" >> $SINGULARITY_ENVIRONMENT
+    #cp /opt/intel/oneapi/setvars.sh /.singularity.d/env/
+    #chmod a+x /.singularity.d/env/setvars.sh
+
+    # can I get these from sourcing /opt/intel/oneapi/setupvar.sh?
+
+    echo 'export MKLROOT=/opt/intel/oneapi/mkl/2022.0.2' >>$SINGULARITY_ENVIRONMENT
+    echo 'export CPATH=/opt/intel/oneapi/tbb/2021.5.1/env/../include:/opt/intel/oneapi/mkl/2022.0.2/include' >>$SINGULARITY_ENVIRONMENT
+    echo 'export NLSPATH=/opt/intel/oneapi/mkl/2022.0.2/lib/intel64/locale/%l_%t/%N:/opt/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin/locale/%l_%t/%N' >>$SINGULARITY_ENVIRONMENT
+    echo 'export LIBRARY_PATH=/opt/intel/oneapi/tbb/2021.5.1/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2022.0.2/lib/intel64:/opt/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/2022.0.2/linux/lib' >>$SINGULARITY_ENVIRONMENT
+    echo 'export LD_LIBRARY_PATH=/opt/intel/oneapi/tbb/2021.5.1/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/mkl/2022.0.2/lib/intel64:/opt/intel/oneapi/compiler/2022.0.2/linux/lib:/opt/intel/oneapi/compiler/2022.0.2/linux/lib/x64:/opt/intel/oneapi/compiler/2022.0.2/linux/compiler/lib/intel64_lin' >>$SINGULARITY_ENVIRONMENT
+
+%runscript
+    echo "Container was created $NOW"
+    echo "Arguments received: $*"
+    echo "MKLROOT is $MKLROOT"
+    echo $MKLROOT
+    echo "other test is $othertest"
+    echo $othertest
+    exec echo "$@"
+
+
+%startscript
+    nc -lp $LISTEN_PORT
+
+%test
+    grep -q NAME=\"Ubuntu\" /etc/os-release
+    if [ $? -eq 0 ]; then
+        echo "Container base is Ubuntu as expected."
+    else
+        echo "Container base is not Ubuntu."
+        exit 1
+    fi
+
+#    /cisTEM/bin/console_test
+
+%labels
+    Author BAH
+    Version v1.0.2 (21986909a60d7579dc1dde9c1c977fd033dcdebe)
+

--- a/src/core/core_headers.h
+++ b/src/core/core_headers.h
@@ -46,7 +46,9 @@ const std::complex<float> I(0.0, 1.0);
 #include <vector>
 #include <random>
 #include <functional>
-#include <fftw3.h>
+// These are in $MKLROOT/include
+#include <fftw/fftw3.h>
+#include <fftw/fftw3_mkl.h>
 #include <math.h>
 #include <chrono>
 #include "sqlite/sqlite3.h"


### PR DESCRIPTION
# Description

See reasoning in file FFT_LICENSE_NOTE

CPU code is *actually* dynamically compiled now, reduces build directory size from 5.7->1.1 Gb

Dockerfile adds Intel mkl one API - removing as much as possible to reduce from 4.4->0.8 Gb

I've included a singularity build recipe in scripts/ 

Fixes #57 

# I have rebased my feature branch to be current with the master branch using to minimize conflicts and headaches

- [X] yes
- [ ] no

# Which compilers were tested

- [X] g++
- [ ] icpc
- [ ] clang
- [ ] other (please specify)

# These changes are isolated to the

- [ ] gui
- [X] core library
- [ ] gpu core library
- [ ] program it modifies

# How has the functionality been tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [X] Tested manually from GUI
- [X] Tested manually from CLI
- [X] Passed console tests
- [X] Passed samples functional testing
- [X] other 
I ran the apo tutorial on both a recent intel build and this build. Results and times were nominally dientical.

# Checklist:

- [X] I have not changed anything that did not need to be changed
- [X] I have performed a self-review of my own code
- [X] I have commented my code, (***w.r.t. why***), particularly in hard-to-understand areas
- [X] I have made corresponding changes to the [documentation](https://github.com/bHimes/cisTEM_docs) {Ok to pass for now}
- [ ] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
